### PR TITLE
line 73 将 jobeet.local 改为 jobeet.local.config

### DIFF
--- a/chapter-01/chapter-01.md
+++ b/chapter-01/chapter-01.md
@@ -70,7 +70,7 @@
 
     sudo nano /etc/apache2/sites-available/jobeet.local
 
-好了，我们创建了一个*jobeet.local*文件。接下来，把下面的代码复制到*jobeet.local*文件中，然后按下*Control-O*，回车进行保存，然后*Control-X*退出编辑器。
+好了，我们创建了一个*jobeet.local*文件。接下来，把下面的代码复制到*jobeet.local.config*文件中，然后按下*Control-O*，回车进行保存，然后*Control-X*退出编辑器。
 
     <VirtualHost *:80>
         ServerName jobeet.local


### PR DESCRIPTION
在 /etc/apache2/apache2.conf 中默认有只读 .conf 文件的设置
# Include generic snippets of statements

IncludeOptional conf-enabled/*.conf

应此执行 sudo a2ensite jobeet.local 是由于没有找到配置文件，会出现 ERROR: Site jobeet.local does not exist! 错误
