### PR TITLE
补全Affiliate和Category实体的双向映射关系定义

### DIFF
--- a/chapter-03/chapter-03.md
+++ b/chapter-03/chapter-03.md
@@ -155,6 +155,7 @@ Ibw\JobeetBundle\Entity\Affiliate:
     manyToMany:
         categories:
             targetEntity: Category
+            inversedBy: affiliates
             joinTable:
                 name: category_affiliate
                 joinColumns:


### PR DESCRIPTION
Symfony 2.5.*， 查看debug信息，在Mapping errors里出现如下错误

> ```
> The field Ibw\JobeetBundle\Entity\Category#affiliates is on the inverse side of a bi-directional relationship,  the specified mappedBy association on the target-entity Ibw\JobeetBundle\Entity\Affiliate#categories not contain the required 'inversedBy=affiliates' attribute.
> ```

Affiliate作为映射关系的拥有者，需要定义inversedBy。
